### PR TITLE
query string rules to enforce the usage of parameters instead of conc…

### DIFF
--- a/Apps/WindmillPP/WindmillPP.dpr
+++ b/Apps/WindmillPP/WindmillPP.dpr
@@ -27,7 +27,8 @@ uses
   WindmillPP.CmdLine in 'runner\WindmillPP.CmdLine.pas',
   uUnitLines in '..\..\Core\uUnitLines.pas',
   Input.Params.CmdLine in 'input\Input.Params.CmdLine.pas',
-  Input.Params.Interfaces in 'input\Input.Params.Interfaces.pas';
+  Input.Params.Interfaces in 'input\Input.Params.Interfaces.pas',
+  Rules.QueryStrings in 'rules\Rules.QueryStrings.pas';
 
 var
   Mill: IWindmillPP;

--- a/Apps/WindmillPP/WindmillPP.dproj
+++ b/Apps/WindmillPP/WindmillPP.dproj
@@ -98,6 +98,7 @@
         <DCCReference Include="..\..\Core\uUnitLines.pas"/>
         <DCCReference Include="input\Input.Params.CmdLine.pas"/>
         <DCCReference Include="input\Input.Params.Interfaces.pas"/>
+        <DCCReference Include="rules\Rules.QueryStrings.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Apps/WindmillPP/WindmillUnitTests.dpr
+++ b/Apps/WindmillPP/WindmillUnitTests.dpr
@@ -34,7 +34,9 @@ uses
   Input.Params.Interfaces in 'input\Input.Params.Interfaces.pas',
   Input.Params.CmdLine in 'input\Input.Params.CmdLine.pas',
   Rules.Overridden in 'rules\Rules.Overridden.pas',
-  Rules.Overridden.Tests in 'rules\Rules.Overridden.Tests.pas';
+  Rules.Overridden.Tests in 'rules\Rules.Overridden.Tests.pas',
+  Rules.QueryStrings in 'rules\Rules.QueryStrings.pas',
+  Rules.QueryStrings.Tests in 'rules\Rules.QueryStrings.Tests.pas';
 
 type
   TTestGripExcept = class

--- a/Apps/WindmillPP/WindmillUnitTests.dproj
+++ b/Apps/WindmillPP/WindmillUnitTests.dproj
@@ -100,6 +100,8 @@
         <DCCReference Include="input\Input.Params.CmdLine.pas"/>
         <DCCReference Include="rules\Rules.Overridden.pas"/>
         <DCCReference Include="rules\Rules.Overridden.Tests.pas"/>
+        <DCCReference Include="rules\Rules.QueryStrings.pas"/>
+        <DCCReference Include="rules\Rules.QueryStrings.Tests.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Apps/WindmillPP/rules/Rules.Method.All.pas
+++ b/Apps/WindmillPP/rules/Rules.Method.All.pas
@@ -21,7 +21,7 @@ type
 implementation
 
 uses
-  Rules.Without, Rules.Overridden;
+  Rules.Without, Rules.Overridden, Rules.QueryStrings;
 
 constructor TRulesMethodAll.Create(const Output: IOutput);
 begin
@@ -37,8 +37,11 @@ begin
   CurrentRule.Process(Filepath, ClassDef, Method, Lines);
 
   // next...
-
   CurrentRule := TRulesOverridden.Create(FOutput);
+  CurrentRule.Process(Filepath, ClassDef, Method, Lines);
+
+  // ..
+  CurrentRule := TRulesQueryStrings.Create(FOutput);
   CurrentRule.Process(Filepath, ClassDef, Method, Lines);
 end;
 

--- a/Apps/WindmillPP/rules/Rules.QueryStrings.Tests.pas
+++ b/Apps/WindmillPP/rules/Rules.QueryStrings.Tests.pas
@@ -1,0 +1,151 @@
+unit Rules.QueryStrings.Tests;
+
+interface
+
+uses
+  uPascalDefs,
+  System.Classes,
+  DUnitX.TestFramework,
+  Delphi.Mocks,
+  Output.Interfaces,
+  Rules.Interfaces;
+
+type
+  [TestFixture]
+  TRulesQueryStringsTests = class
+  private
+    FOutput: TMock<IOutput>;
+    FRules: IRulesOnMethod;
+
+    FCurrentMethod: TMethodDefinition;
+    FCurrentCode: TStringList;
+
+    FCurrentFile: string;
+    FCurrentClass: TClassDefinition;
+
+  public
+    [Setup]
+    procedure Setup;
+
+    [Teardown]
+    procedure Teardown;
+
+    [Test]
+    procedure BasicTest;
+
+    [Test]
+    procedure BasicTestWithIfElseEnd;
+
+    [Test]
+    procedure SQLAddTest;
+
+    [Test]
+    procedure OkSQLAddTest;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  Rules.QueryStrings;
+
+procedure TRulesQueryStringsTests.Setup;
+begin
+  FOutput := TMock<IOutput>.Create;
+  FRules := TRulesQueryStrings.Create(FOutput);
+  FCurrentCode := TStringList.Create;
+  FCurrentMethod := TMethodDefinition.Create('procedure DoSomethingWithMyObject', True, TClassScope.csPublic);
+end;
+
+procedure TRulesQueryStringsTests.Teardown;
+begin
+  FreeAndNil(FCurrentCode);
+  FreeAndNil(FCurrentMethod);
+end;
+
+procedure TRulesQueryStringsTests.BasicTest;
+begin
+  FCurrentCode.Text :=
+    'var'#13#10 +
+    '  Param1: string;'#13#10 +
+    'begin'#13#10 +
+    '  MyObject.SQL.Text := ''select * from mytable where param='' + Param1;'#13#10 +
+    'end;';
+
+  FOutput.Setup.Expect.Never('Info');
+  FOutput.Setup.Expect.Never('Warning');
+  FOutput.Setup.Expect.Once('Error');
+
+  FRules.Process(FCurrentFile, FCurrentClass, FCurrentMethod, FCurrentCode);
+
+  FOutput.Verify;
+end;
+
+procedure TRulesQueryStringsTests.BasicTestWithIfElseEnd;
+begin
+  FCurrentCode.Text :=
+    'var'#13#10 +
+    '  Param1: string;'#13#10 +
+    'begin'#13#10 +
+    '  if true then begin'#13#10 +
+    '    MyObject.SQL.Text := ''select * from mytable where param=:Param1'''#13#10 +
+    '  end if False then'#13#10 +
+    '    MyObject.SQL.Text := ''select * from mytable where param=:Param1'''#13#10 +
+    '  else'#13#10 +
+    '    MyObject.SQL.Text := ''select * from mytable where param=:Param1'';'#13#10 +
+    'end;';
+
+  FOutput.Setup.Expect.Never('Info');
+  FOutput.Setup.Expect.Never('Warning');
+  FOutput.Setup.Expect.Never('Error');
+
+  FRules.Process(FCurrentFile, FCurrentClass, FCurrentMethod, FCurrentCode);
+
+  FOutput.Verify;
+end;
+
+procedure TRulesQueryStringsTests.SQLAddTest;
+begin
+  FCurrentCode.Text :=
+    'begin'#13#10 +
+    '  FDataset.SQL.Clear;'#13#10 +
+    '  FDataset.SQL.Text := FSql_org.Text;'#13#10 +
+    '  if pos(''WHERE'', UpperCase(FSql_org.Text)) > 0 then'#13#10 +
+    '    FDataset.SQL.Add('' AND '' + volgorde.Strings[0] + '' >= '' + Edit_Van.Text +'#13#10 +
+    '                     '' AND '' + volgorde.Strings[0] + '' <= '' + Edit_TotEnMet.Text + '')'#13#10 +
+    '  else'#13#10 +
+    '    FDataset.SQL.Add(''WHERE '' + volgorde.Strings[0] + '' >= '' + Edit_Van.Text +'#13#10 +
+    '                     '' AND '' + volgorde.Strings[0] + '' <= '' + Edit_TotEnMet.Text + '');'#13#10 +
+    ''#13#10 +
+    '  if Edit_Volgorde.Text <> '' then'#13#10 +
+    '     FDataset.SQL.Add(''Order By '' + Edit_Volgorde.Text);'#13#10 +
+    ''#13#10 +
+    '  FDataset.Active := True;' +
+    'end;';
+
+  FOutput.Setup.Expect.Never('Info');
+  FOutput.Setup.Expect.AtLeastOnce('Warning');
+  FOutput.Setup.Expect.Exactly('Error', 2);
+
+  FRules.Process(FCurrentFile, FCurrentClass, FCurrentMethod, FCurrentCode);
+
+  FOutput.Verify;
+end;
+
+procedure TRulesQueryStringsTests.OkSQLAddTest;
+begin
+  FCurrentCode.Text :=
+    'begin'#13#10 +
+    '  Query.Sql.Add(''Delete from Bev_Special_rechten'');'#13#10 +
+    'end;';
+
+  FOutput.Setup.Expect.Never('Info');
+  FOutput.Setup.Expect.Never('Warning');
+  FOutput.Setup.Expect.Never('Error');
+
+  FRules.Process(FCurrentFile, FCurrentClass, FCurrentMethod, FCurrentCode);
+
+  FOutput.Verify;
+end;
+
+end.

--- a/Apps/WindmillPP/rules/Rules.QueryStrings.pas
+++ b/Apps/WindmillPP/rules/Rules.QueryStrings.pas
@@ -1,0 +1,319 @@
+unit Rules.QueryStrings;
+
+interface
+
+uses
+  Rules.Interfaces,
+  Output.Interfaces,
+  System.Classes,
+  System.RegularExpressions,
+  System.Generics.Collections,
+  uPascalDefs;
+
+type
+  {$SCOPEDENUMS ON}
+  TQueryStringPartType = (
+    Unknown = 0,
+    QuotedString = 1,
+    ConcatPlus = 2,
+    CRLF = 3,
+    ParameterInString = 4,
+    VariableOutside = 5,
+    TheEnd = 6
+  );
+  {$SCOPEDENUMS OFF}
+
+  TQueryStringPart = class
+  public
+    PartType: TQueryStringPartType;
+    Content: string;
+  end;
+
+  TRulesQueryStrings = class(TInterfacedObject, IRulesOnMethod)
+  private
+    FOutput: IOutput;
+    FSourceCode: TStrings;
+    FSQLTextAssignmentRegex: TRegEx;
+    FSQLAssignmentRegex: TRegEx;
+    FSQLAddRegex: TRegEx;
+
+    FCurrentQuery: TList<TQueryStringPart>;
+
+    function HasVariableOutside: Boolean;
+    function DefinitelyHasVariablesThatShouldBeParameters: Boolean;
+
+    procedure UnwrapStringFrom(const StartIdx: Integer);
+    function HasSQLAssignments: Boolean;
+
+    procedure ProcessWithRegex(const Regex: TRegex; const Filepath: string; const Classdef: TClassDefinition; const Method: TMethodDefinition);
+  public
+    constructor Create(const Output: IOutput);
+    destructor Destroy; override;
+
+    procedure Process(const Filepath: string; const Classdef: TClassDefinition; const Method: TMethodDefinition; const Lines: TStrings);
+  end;
+
+implementation
+
+uses
+  System.StrUtils, System.SysUtils, uCommonFunctions;
+
+constructor TRulesQueryStrings.Create(const Output: IOutput);
+begin
+  FOutput := Output;
+  FSQLTextAssignmentRegex := TRegEx.Create('sql.text\s*:=', [roIgnoreCase]);
+  FSQLAssignmentRegex := TRegEx.Create('sql\s*:=', [roIgnoreCase]);
+  FSQLAddRegex := TRegEx.Create('sql.add\(', [roIgnoreCase]);
+end;
+
+destructor TRulesQueryStrings.Destroy;
+begin
+  FreeAndNil(FCurrentQuery)
+end;
+
+function TRulesQueryStrings.HasSQLAssignments: Boolean;
+begin
+  Result :=
+    FSQLTextAssignmentRegex.IsMatch(FSourceCode.Text) or
+    FSQLAssignmentRegex.IsMatch(FSourceCode.Text) or
+    FSQLAddRegex.IsMatch(FSourceCode.Text);
+end;
+
+procedure TRulesQueryStrings.UnwrapStringFrom(const StartIdx: Integer);
+var
+  Idx, Len: Integer;
+  CurrentChar: Char;
+  CurrentPart: TQueryStringPart;
+  CheckEndElse: string;
+begin
+  FreeAndNil(FCurrentQuery);
+  FCurrentQuery := TList<TQueryStringPart>.Create;
+
+  CurrentPart := TQueryStringPart.Create;
+  FCurrentQuery.Add(CurrentPart);
+
+  Idx := StartIdx;
+
+  Len := FSourceCode.Text.Length;
+  while Idx <= Len do
+  begin
+    CurrentChar := FSourceCode.Text[Idx];
+    if (CurrentPart.PartType = TQueryStringPartType.Unknown) then
+    begin
+      if CurrentChar = '''' then
+      begin
+        CurrentPart.PartType := TQueryStringPartType.QuotedString;
+      end
+      else if CurrentChar = '+' then
+      begin
+        CurrentPart.PartType := TQueryStringPartType.ConcatPlus;
+      end
+      else if CurrentChar = '#' then
+      begin
+        CurrentPart.PartType := TQueryStringPartType.CRLF;
+        CurrentPart.Content := '#';
+      end
+      else if CurrentChar = ';' then
+      begin
+        CurrentPart.PartType := TQueryStringPartType.TheEnd;
+        Break;
+      end
+      else if CharInSet(CurrentChar, [' ',#9,#13,#10]) then
+      begin
+        // ignore spacing
+      end
+      else if CurrentChar = ')' then
+      begin
+        CurrentPart.PartType := TQueryStringPartType.TheEnd;
+        CurrentPart.Content := CurrentPart.Content + CurrentChar;
+      end
+      else
+      begin
+        CurrentPart.PartType := TQueryStringPartType.VariableOutside;
+        CurrentPart.Content := CurrentPart.Content + CurrentChar;
+      end;
+    end
+    else if (CurrentPart.PartType = TQueryStringPartType.QuotedString) then
+    begin
+      if CurrentChar = '''' then
+      begin
+        if ((Idx+1) <= Len) and (FSourceCode.Text[Idx+1] = '''') then
+        begin
+          // just an escaped single quote
+          CurrentPart.Content := CurrentPart.Content + '''';
+          Inc(Idx);
+        end
+        else
+        begin
+          CurrentPart := TQueryStringPart.Create;
+          FCurrentQuery.Add(CurrentPart);
+        end;
+      end
+      else
+      begin
+        CurrentPart.Content := CurrentPart.Content + CurrentChar;
+      end;
+    end
+    else if (CurrentChar = '+') then
+    begin
+      CurrentPart := TQueryStringPart.Create;
+      CurrentPart.PartType := TQueryStringPartType.ConcatPlus;
+      FCurrentQuery.Add(CurrentPart);
+    end
+    else if CurrentChar = ';' then
+    begin
+      CurrentPart := TQueryStringPart.Create;
+      CurrentPart.PartType := TQueryStringPartType.TheEnd;
+      FCurrentQuery.Add(CurrentPart);
+      Break;
+    end
+    else if CurrentChar = ')' then
+    begin
+      CurrentPart := TQueryStringPart.Create;
+      CurrentPart.PartType := TQueryStringPartType.Unknown;
+      FCurrentQuery.Add(CurrentPart);
+    end
+    else if CurrentPart.PartType = TQueryStringPartType.ConcatPlus then
+    begin
+      CurrentPart := TQueryStringPart.Create;
+      FCurrentQuery.Add(CurrentPart);
+    end
+    else
+    begin
+      CurrentPart.Content := CurrentPart.Content + CurrentChar;
+
+      CheckEndElse := CurrentPart.Content.TrimLeft;
+      if (CheckEndElse.StartsWith('else', True) and (CheckEndElse.Length > 4) and (CharInSet(CheckEndElse[5], [';',' ',#13,#10,#9]))) or
+         (CheckEndElse.StartsWith('end', True) and (CheckEndElse.Length > 3) and (CharInSet(CheckEndElse[4], [';',' ',#13,#10,#9]))) then
+      begin
+        CurrentPart.PartType := TQueryStringPartType.TheEnd;
+        Break;
+      end;
+    end;
+
+    Inc(Idx);
+  end;
+end;
+
+function TRulesQueryStrings.HasVariableOutside: Boolean;
+var
+  Part: TQueryStringPart;
+  HasQuotedString: Boolean;
+  HasVars: Boolean;
+begin
+  HasQuotedString := False;
+  HasVars := False;
+
+  for Part in FCurrentQuery do
+  begin
+    if Part.PartType = TQueryStringPartType.QuotedString then
+    begin
+      HasQuotedString := True;
+    end
+    else if Part.PartType = TQueryStringPartType.VariableOutside then
+    begin
+      HasVars := True;
+    end;
+  end;
+
+  Result := HasQuotedString and HasVars;
+end;
+
+function TRulesQueryStrings.DefinitelyHasVariablesThatShouldBeParameters: Boolean;
+var
+  Part: TQueryStringPart;
+  PreviousString: string;
+  VariablePrecededByComparison: Boolean;
+begin
+  PreviousString := '';
+  VariablePrecededByComparison := False;
+
+  Result := False;
+
+  for Part in FCurrentQuery do
+  begin
+    if Part.PartType = TQueryStringPartType.QuotedString then
+    begin
+      if VariablePrecededByComparison then
+      begin
+        if Part.Content.TrimLeft.StartsWith('.') then
+        begin
+          VariablePrecededByComparison := False;
+        end;
+      end;
+
+      if VariablePrecededByComparison then
+      begin
+        Break;
+      end;
+
+      PreviousString := Part.Content.TrimRight;
+    end
+    else if Part.PartType = TQueryStringPartType.VariableOutside then
+    begin
+      VariablePrecededByComparison :=
+        PreviousString.EndsWith('like', True) or
+        PreviousString.EndsWith('=') or
+        PreviousString.EndsWith('>') or
+        PreviousString.EndsWith('<') or
+        PreviousString.EndsWith('''');
+    end
+    else if Part.PartType = TQueryStringPartType.ConcatPlus then
+    begin
+      // skip the glue
+    end
+    else if VariablePrecededByComparison then
+    begin
+      Break;
+    end;
+  end;
+
+  if VariablePrecededByComparison then
+    Result := True;
+end;
+
+procedure TRulesQueryStrings.ProcessWithRegex(const Regex: TRegex; const Filepath: string; const Classdef: TClassDefinition; const Method: TMethodDefinition);
+var
+  Matches: TMatchCollection;
+  Match: TMatch;
+  StartLineOfQuery: Integer;
+begin
+  Matches := Regex.Matches(FSourceCode.Text, 1);
+  for Match in Matches do
+  begin
+    if Match.Success then
+    begin
+      UnwrapStringFrom(Match.Index + Match.Length);
+
+      if HasVariableOutside then
+      begin
+        StartLineOfQuery := TCommonStringFunctions.CountLines(FSourceCode.Text, lfDos, Match.Index + Match.Length);
+
+        if DefinitelyHasVariablesThatShouldBeParameters then
+        begin
+          FOutput.Error(Filepath, Method.LineNumber + StartLineOfQuery + 1, 'SQL Query has concattenated variables that SHOULD be parameters');
+        end
+        else
+        begin
+          FOutput.Warning(Filepath, Method.LineNumber + StartLineOfQuery + 1, 'SQL Query has concattenated variables that MIGHT be parameters, check to be sure');
+        end;
+      end;
+    end;
+  end;
+end;
+
+procedure TRulesQueryStrings.Process(const Filepath: string; const Classdef: TClassDefinition; const Method: TMethodDefinition; const Lines: TStrings);
+begin
+  FSourceCode := Lines;
+
+  if HasSQLAssignments then
+  begin
+    ProcessWithRegex(FSQLTextAssignmentRegex, Filepath, Classdef, Method);
+
+    ProcessWithRegex(FSQLAssignmentRegex, Filepath, Classdef, Method);
+
+    ProcessWithRegex(FSQLAddRegex, Filepath, Classdef, Method);
+  end;
+end;
+
+end.

--- a/Apps/WindmillPP/runner/WindmillPP.CmdLine.pas
+++ b/Apps/WindmillPP/runner/WindmillPP.CmdLine.pas
@@ -78,8 +78,15 @@ procedure TWindmillPPCmdLine.RunOnUnit(const Filepath: string);
 var
   Runner: IRunner;
 begin
-  Runner := TRunnerDefault.Create(FOutput);
-  Runner.Execute(Filepath);
+  if not FileExists(FilePath) then
+  begin
+    FOutput.Warning(Filepath, 0, 'Unit doesn''t exist, but is added to dproject file');
+  end
+  else
+  begin
+    Runner := TRunnerDefault.Create(FOutput);
+    Runner.Execute(Filepath);
+  end;
 end;
 
 end.


### PR DESCRIPTION
…attenated strings